### PR TITLE
Added HOC to prevent users from hitting certain routes when authenticated

### DIFF
--- a/client/src/pages/authentication/signin/index.js
+++ b/client/src/pages/authentication/signin/index.js
@@ -10,6 +10,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import FormModal from "../components/FormModal";
+import { unauthenticatedRoute } from "../../../utils";
 import ReduxTextField from "../../../components/ReduxTextField";
 
 const useStyle = makeStyles({
@@ -116,4 +117,4 @@ function mapStateToProps(state) {
 export default compose(
   connect(mapStateToProps, actions),
   reduxForm({ form: "signin" })
-)(Signin);
+)(unauthenticatedRoute(Signin));

--- a/client/src/pages/authentication/signup/index.js
+++ b/client/src/pages/authentication/signup/index.js
@@ -10,6 +10,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import FormModal from "../components/FormModal";
+import { unauthenticatedRoute } from "../../../utils";
 import ReduxTextField from "../../../components/ReduxTextField";
 
 const useStyle = makeStyles({
@@ -116,4 +117,4 @@ function mapStateToProps(state) {
 export default compose(
   connect(mapStateToProps, actions),
   reduxForm({ form: "signup" })
-)(Signup);
+)(unauthenticatedRoute(Signup));

--- a/client/src/pages/authentication/welcome/index.js
+++ b/client/src/pages/authentication/welcome/index.js
@@ -5,6 +5,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
+import { unauthenticatedRoute } from "../../../utils";
 import FormModal from "../components/FormModal";
 
 const useStyle = makeStyles({
@@ -59,4 +60,4 @@ const Welcome = () => {
   );
 };
 
-export default Welcome;
+export default unauthenticatedRoute(Welcome);

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -11,10 +11,36 @@ export const requireAuth = (ChildComponent) => {
     componentDidUpdate() {
       this.shouldNavigateAway();
     }
-    // If the user is not authenticated, redirect them back to the root page
+    // If the user is not authenticated, redirect them back to the welcome page
     shouldNavigateAway() {
       if (!this.props.auth) {
         this.props.history.push("/");
+      }
+    }
+    render() {
+      return <ChildComponent {...this.props} />;
+    }
+  }
+  function mapStateToProps(state) {
+    return { auth: state.auth.authenticated };
+  }
+  return connect(mapStateToProps)(ComposedComponent);
+};
+
+export const unauthenticatedRoute = (ChildComponent) => {
+  class ComposedComponent extends Component {
+    // Our component just got rendered
+    componentDidMount() {
+      this.shouldNavigateAway();
+    }
+    // Our component just got updated
+    componentDidUpdate() {
+      this.shouldNavigateAway();
+    }
+    // If the user is already authenticated, redirect them to the home page
+    shouldNavigateAway() {
+      if (this.props.auth) {
+        this.props.history.push("/home");
       }
     }
     render() {


### PR DESCRIPTION
PR includes: 
- Added a HOC to prevent users from landing on certain routes if they are already authenticated. Trying to hit these routes when authenticated will redirect users to `/home`, the home page of the app.
- Wrapped the Welcome page, sign-in page, and sign-up page with the new HOC.